### PR TITLE
[FR] Fix french translation, #16

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -40,13 +40,15 @@ export default {
   },
   fr: {
     LoginScreen: {
-      Hibernate: "Hiberer",
+      Hibernate: "Hiberner",
       Suspend: "Suspendre",
       Restart: "Redémarrer",
-      Shutdown: "Arrêt de l'appareil",
-      Lock: "Verrou",
+      Shutdown: "Arrêter",
+      Lock: "Verrouiller",
       UserPlaceholder: "Utilisateur",
-      PasswordPlaceholder: "Mot de passe"
+      PasswordPlaceholder: "Mot de passe",
+      UsernameWarning: "Veuillez saisir votre nom d'utilisateur.",
+      PasswordWarning: "Veuillez saisir votre mot de passe."
     }
   },
   'sv': {


### PR DESCRIPTION
Fix bad translation on french language and add missing (`UsernameWarning` and `PasswordWarning`).