### PR TITLE
create AUR package file

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,25 @@
+pkgname=lightdm-webkit2-theme-iskra
+_pkgname=iskra
+pkgver=v1.1.2.r65.c3de83e
+pkgrel=1
+pkgdesc="A beautiful and simple lockscreen for LightDM made with React"
+arch=('any')
+url="https://github.com/felipemarinho97/iskra-webkit-greeter"
+license=('MIT')
+groups=()
+depends=('lightdm' 'lightdm-webkit2-greeter')
+makedepends=('git') # 'bzr', 'git', 'mercurial' or 'subversion'
+provides=("${pkgname%-git}")
+replaces=("${pkgname%-git}")
+source=("${pkgname}::git+https://github.com/felipemarinho97/iskra-webkit-greeter")
+md5sums=('SKIP')
+
+pkgver() {
+	cd "$srcdir/${pkgname%-git}"
+	printf "%s" "$(git describe --tag | sed 's/\([^-]*-\)g/r\1/;s/-/./g')"
+}
+
+package() {
+	install -dm755 "$pkgdir/usr/share/lightdm-webkit/themes/$_pkgname"
+	cp -r "$srcdir/${pkgname}/"* "$pkgdir/usr/share/lightdm-webkit/themes/$_pkgname"
+}


### PR DESCRIPTION
May I suggest changing the name of the git repository to `lightdm-webkit2-theme-iskra` for sake of consistency with other AUR packages? Refer to: [Material2 Theme](https://github.com/FallingSnow/lightdm-webkit2-material2) [Arch Theme](https://github.com/kenogo/lightdm-webkit2-theme-arch).

`iskra-webkit-greeter` is somewhat confusing as the `greeter` usually refers to the framework used by lightdm.